### PR TITLE
Use 'npm start' instead of 'node boostrap.js.'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Basic Minecraft Bedrock Edition software ",
   "main": "bootstrap.js",
   "scripts": {
+    "start": "node bootstrap.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/start.cmd
+++ b/start.cmd
@@ -17,6 +17,6 @@ echo You have to install Node.js
 exit
 
 :launch
-node bootstrap.js
+npm start
 timeout 5 > nul
 goto launch

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 DIR="./node_modules/"
 if [ -d "$DIR" ]; then
-  node bootstrap.js
+  npm start
   else
     echo "Installing dependencies..." 
     npm i
     clear
-    node bootstrap.js
+    npm start
 fi


### PR DESCRIPTION
This simplifies the start script incase of changes to the bootstrapping process (eg y'all decide to switch to using babel/typescript etc).