### PR TITLE
Stop command should exit the process with 0.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -55,6 +55,7 @@ rl.on('line', (input) => {
     )
 })
 
-server.listen().catch(() => 
+server.listen().catch(() => {
     logger.error(`Cannot start the server, is it already running on the same port?`)
-)
+    process.exit(1)
+})

--- a/src/command/vanilla/stop-command.js
+++ b/src/command/vanilla/stop-command.js
@@ -20,7 +20,7 @@ class StopCommand extends Command {
         await sender.getServer().getServer().kill()
 
         sender.getServer().getLogger().warn('Server is closing...')
-        setTimeout(() => { process.exit(1) }, 1000)
+        setTimeout(() => { process.exit(0) }, 1000)
     }
 }
 module.exports = StopCommand


### PR DESCRIPTION
As per the unix specification
> exit code (0) means an exit without an errors or issues.
> exit code (1) means there was some issue / problem which caused the program to exit.

(this also fixes an issue where the process wouldn't exit upon the port already being used).